### PR TITLE
[PR](Middleware): Fixed middleware being too hard on routing

### DIFF
--- a/ansible/deploy.sh
+++ b/ansible/deploy.sh
@@ -100,7 +100,7 @@ run_dependencies() {
     echo
     echo -e "${GREEN}🔧 Installing Dependencies on All Hosts${NC}"
     echo -e "${YELLOW}📋 Running: ansible-playbook playbook.yml${NC}"
-    ansible-playbook playbook.yml -v
+    ansible-playbook playbook.yml
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ Dependencies installed successfully!${NC}"
@@ -114,7 +114,7 @@ run_staging_deployment() {
     echo
     echo -e "${GREEN}🎯 Deploying to Staging Environment${NC}"
     echo -e "${YELLOW}📋 Running: ansible-playbook playbook-staging.yml${NC}"
-    ansible-playbook playbook-staging.yml -v
+    ansible-playbook playbook-staging.yml
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ Staging deployment completed successfully!${NC}"
@@ -128,7 +128,7 @@ run_production_deployment() {
     echo
     echo -e "${GREEN}🎯 Deploying to Production Environment${NC}"
     echo -e "${YELLOW}📋 Running: ansible-playbook playbook-production.yml${NC}"
-    ansible-playbook playbook-production.yml -v
+    ansible-playbook playbook-production.yml
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ Production deployment completed successfully!${NC}"
@@ -143,7 +143,7 @@ run_full_deployment() {
     echo -e "${GREEN}🎯 Deploying to Both Environments${NC}"
 
     echo -e "${YELLOW}📋 Step 1/3: Installing dependencies...${NC}"
-    ansible-playbook playbook.yml -v
+    ansible-playbook playbook.yml
 
     if [ $? -ne 0 ]; then
         echo -e "${RED}❌ Dependencies installation failed!${NC}"
@@ -151,7 +151,7 @@ run_full_deployment() {
     fi
 
     echo -e "${YELLOW}📋 Step 2/3: Deploying to staging...${NC}"
-    ansible-playbook playbook-staging.yml -v
+    ansible-playbook playbook-staging.yml
 
     if [ $? -ne 0 ]; then
         echo -e "${RED}❌ Staging deployment failed!${NC}"
@@ -159,7 +159,7 @@ run_full_deployment() {
     fi
 
     echo -e "${YELLOW}📋 Step 3/3: Deploying to production...${NC}"
-    ansible-playbook playbook-production.yml -v
+    ansible-playbook playbook-production.yml
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ Full deployment completed successfully!${NC}"

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { verifyJwtEdge } from './src/infrastructure/security/auth-edge';
 
-const PUBLIC_PATHS = ['/login','/signup','/favicon.ico', '/'];
+const PUBLIC_PATHS = ['/login', '/signup', '/favicon.ico', '/', '/about', '/news', '/events', '/projects', '/health', '/home', '/logo.png'];
 
 function isPublic(path: string): boolean {
   if (PUBLIC_PATHS.includes(path)) return true;
+  if (path.startsWith('/auth/')) return true;
   if (path.startsWith('/api/auth/')) return true;
   if (path.startsWith('/api/health')) return true;
   if (path.startsWith('/api/sync/')) return true;
@@ -16,7 +17,7 @@ function isPublic(path: string): boolean {
   if (path.startsWith('/api/partners')) return true;
   if (path.startsWith('/api/users')) return true;
   if (path.startsWith('/_next/') || path.startsWith('/static/')) return true;
-  if (path.startsWith('/public/')) return true;
+  if (path.match(/\.(png|jpg|jpeg|gif|svg|ico|css|js|woff|woff2|ttf|eot)$/)) return true;
   return false;
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -17,7 +17,7 @@ function isPublic(path: string): boolean {
   if (path.startsWith('/api/partners')) return true;
   if (path.startsWith('/api/users')) return true;
   if (path.startsWith('/_next/') || path.startsWith('/static/')) return true;
-  if (path.match(/\.(png|jpg|jpeg|gif|svg|ico|css|js|woff|woff2|ttf|eot)$/)) return true;
+  if (path.match(/\.(png|jpg|jpeg|gif|svg|ico|css|js|woff|woff2|ttf|eot)$/i)) return true;
   return false;
 }
 

--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -9,7 +9,7 @@ else
 fi
 
 echo "Generating initial API documentation..."
-npx apidoc -i src/app/api -o docs/api
+npx tsx scripts/generate-swagger-docs.ts
 
 echo "Starting documentation watcher and server in background..."
 bash scripts/docs-watch.sh &

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,6 +86,12 @@ resource "digitalocean_firewall" "survivor_fw" {
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
 
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "8080"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
   inbound_rule {
     protocol         = "tcp"
     port_range       = "3000"


### PR DESCRIPTION
This pull request includes improvements to deployment scripts, middleware access control, API documentation generation, and infrastructure configuration. The main changes streamline deployment output, expand public route handling, update documentation generation, and enhance firewall rules.

**Deployment script improvements:**

* Removed the `-v` (verbose) flag from all `ansible-playbook` commands in `ansible/deploy.sh` to reduce log verbosity during dependency installation and deployments. [[1]](diffhunk://#diff-7078c2dfe60f93033c7b710aecd30a0cebb6a11d9b040f6a3160cd1b2af7f26bL103-R103) [[2]](diffhunk://#diff-7078c2dfe60f93033c7b710aecd30a0cebb6a11d9b040f6a3160cd1b2af7f26bL117-R117) [[3]](diffhunk://#diff-7078c2dfe60f93033c7b710aecd30a0cebb6a11d9b040f6a3160cd1b2af7f26bL131-R131) [[4]](diffhunk://#diff-7078c2dfe60f93033c7b710aecd30a0cebb6a11d9b040f6a3160cd1b2af7f26bL146-R162)

**Middleware access control enhancements:**

* Expanded the `PUBLIC_PATHS` array in `middleware.ts` to include more public routes such as `/about`, `/news`, `/events`, `/projects`, `/health`, `/home`, and `/logo.png`.
* Updated the `isPublic` function to allow all paths starting with `/auth/`, and to match requests for common static assets by file extension (e.g., `.png`, `.css`, `.js`). [[1]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL5-R9) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL19-R20)

**API documentation generation:**

* Replaced the use of `apidoc` with a TypeScript-based Swagger documentation generator (`generate-swagger-docs.ts`) in `scripts/start-prod.sh`.

**Infrastructure configuration:**

* Added a new outbound firewall rule in `terraform/main.tf` to allow TCP traffic on port `8080` from all sources.