### PR TITLE
[PR](font): Fix font using the good ones

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,7 +48,8 @@
 }
 
 @theme inline {
-  --font-sans: var(--font-geist-sans);
+  --font-sans: 'Open Sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-heading: 'Montserrat', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   --font-mono: var(--font-geist-mono);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -127,9 +128,13 @@ body {
   height: 100%;
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
   overflow-x: hidden;
   overscroll-behavior-y: none;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
 }
 
 .scrollbar-none {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui'],
+        heading: ['var(--font-heading)', 'ui-sans-serif', 'system-ui'],
+      },
       borderRadius: {
         lg: "0.5rem",
         md: "0.375rem",


### PR DESCRIPTION
This pull request updates the application's font system to improve typography consistency and customization. The main changes involve switching to custom font variables for body and heading text, and integrating these into both the global CSS and the Tailwind configuration.

**Font system updates:**

* Updated `--font-sans` and added `--font-heading` CSS variables in `src/app/globals.css` to use `'Open Sans'` for body text and `'Montserrat'` for headings, with comprehensive fallbacks.
* Applied `var(--font-sans)` to the `body` element and set all heading tags (`h1`–`h6`) to use `var(--font-heading)` in `src/app/globals.css`.

**Tailwind CSS integration:**

* Extended the `fontFamily` configuration in `tailwind.config.ts` to use the new CSS variables, enabling utility classes for both sans and heading fonts.